### PR TITLE
複数枚画像投稿を実装

### DIFF
--- a/preview_app_rails7/app/assets/stylesheets/image.css
+++ b/preview_app_rails7/app/assets/stylesheets/image.css
@@ -4,3 +4,22 @@ img {
   /* 縦横比を保ったまま、画像を縦横100pxのサイズに収めるプロパティです */
   object-fit: contain;
 }
+
+.other-images {
+  display: flex;
+}
+
+.other-image {
+  margin-right: 10px;
+}
+
+.image-delete-button {
+  text-align: center;
+  border: solid 1px;
+  cursor: pointer;
+}
+
+.main-image {
+  height: 200px;
+  width: 200px;
+}

--- a/preview_app_rails7/app/assets/stylesheets/preview.css
+++ b/preview_app_rails7/app/assets/stylesheets/preview.css
@@ -5,3 +5,10 @@
 .preview {
   margin-right: 30px;
 }
+
+.image-delete-button {
+  text-align: center;
+  border: solid 1px;
+  cursor: pointer;
+  margin-bottom: 5px;
+}

--- a/preview_app_rails7/app/controllers/posts_controller.rb
+++ b/preview_app_rails7/app/controllers/posts_controller.rb
@@ -31,7 +31,8 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:text, :image)
+    params.require(:post).permit(:text, {images: []})
+    # permitの中でも、images: []の記述は必ず最後に記述しないとエラーになる
   end
 
   def set_post

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -27,6 +27,10 @@ document.addEventListener('turbo:load', function(){
     deleteButton.setAttribute("class", "image-delete-button");
     deleteButton.innerText = "削除";
 
+    // 削除ボタンをクリックしたらプレビューとfile_fieldを削除させる
+    deleteButton.addEventListener("click", () => deleteImage(dataIndex));
+
+
     // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
     previewWrapper.appendChild(deleteButton);

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -9,6 +9,9 @@ document.addEventListener('turbo:load', function(){
   if (!postForm) return null;
   console.log("preview.jsが読み込まれました");
 
+   // 投稿できる枚数の制限を定義
+  const imageLimits = 5;
+
   // プレビュー画像を生成・表示する関数
   const buildPreviewImage = (dataIndex, blob) =>{
   
@@ -103,7 +106,10 @@ document.addEventListener('turbo:load', function(){
       };
 
       buildPreviewImage(dataIndex, blob);
-      buildNewFileField();
+      // buildNewFileField();
+      // 画像の枚数制限に引っかからなければ、新しいfile_fieldを追加する
+      const imageCount = document.querySelectorAll(".preview").length;
+      if (imageCount < imageLimits) buildNewFileField();
   };
 
     // input要素を取得

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -36,5 +36,14 @@ document.addEventListener('turbo:load', function(){
       // 生成したHTMLの要素をブラウザに表示させる
       previewWrapper.appendChild(previewImage);
       previewList.appendChild(previewWrapper);
+
+      // 2枚目用のfile_fieldを作成
+      const newFileField = document.createElement('input');
+      newFileField.setAttribute('type', 'file');
+      newFileField.setAttribute('name', 'post[images][]');
+
+      // 生成したfile_fieldを表示
+      const fileFieldsArea = document.querySelector('.click-upload');
+      fileFieldsArea.appendChild(newFileField);
     });
 });

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -67,6 +67,16 @@ document.addEventListener('turbo:load', function(){
       const blob = window.URL.createObjectURL(file);
       console.log(blob);
 
+      // data-indexを使用して、既にプレビューが表示されているかを確認する
+      const alreadyPreview = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+
+      if (alreadyPreview) {
+        // クリックしたfile_fieldのdata-indexと、同じ番号のプレビュー画像が既に表示されている場合は、画像の差し替えのみを行う
+        const alreadyPreviewImage = alreadyPreview.querySelector("img");
+        alreadyPreviewImage.setAttribute("src", blob);
+        return null;
+      };
+
       buildPreviewImage(dataIndex, blob);
       buildNewFileField();
   };

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -58,10 +58,10 @@ document.addEventListener('turbo:load', function(){
     console.log( dataIndex);
 
     // 古いプレビューが存在する場合は削除
-    const alreadyPreview = document.querySelector('.preview');
-      if (alreadyPreview) {
-        alreadyPreview.remove();
-      };
+    // const alreadyPreview = document.querySelector('.preview');
+      // if (alreadyPreview) {
+        // alreadyPreview.remove();
+      // };
       console.log("input要素で値の変化が起きました");
       const file = e.target.files[0];
       const blob = window.URL.createObjectURL(file);

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -14,6 +14,11 @@ document.addEventListener('turbo:load', function(){
     const fileField = document.querySelector('input[type="file"][name="post[images][]"]');
     // input要素で値の変化が起きた際に呼び出される関数
     fileField.addEventListener('change', function(e){
+
+    // data-index（何番目を操作しているか）を取得
+    const dataIndex = e.target.getAttribute('data-index');
+    console.log( dataIndex);
+    
     // 古いプレビューが存在する場合は削除
     const alreadyPreview = document.querySelector('.preview');
       if (alreadyPreview) {

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -42,6 +42,9 @@ document.addEventListener('turbo:load', function(){
     const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
     newFileField.setAttribute('data-index', nextDataIndex);
 
+    // 追加されたfile_fieldにchangeイベントをセット
+    newFileField.addEventListener("change", changedFileField);
+
     // 生成したfile_fieldを表示
     const fileFieldsArea = document.querySelector('.click-upload');
     fileFieldsArea.appendChild(newFileField);

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -9,16 +9,51 @@ document.addEventListener('turbo:load', function(){
   if (!postForm) return null;
   console.log("preview.jsが読み込まれました");
 
-    // input要素を取得
-    // const fileField = document.querySelector('input[type="file"][name="post[image]"]');
-    const fileField = document.querySelector('input[type="file"][name="post[images][]"]');
-    // input要素で値の変化が起きた際に呼び出される関数
-    fileField.addEventListener('change', function(e){
+  // プレビュー画像を生成・表示する関数
+  const buildPreviewImage = (dataIndex, blob) =>{
+  
+    // 画像を表示するためのdiv要素を生成
+    const previewWrapper = document.createElement('div');
+    previewWrapper.setAttribute('class', 'preview');
+    previewWrapper.setAttribute('data-index', dataIndex);
+
+    // 表示する画像を生成
+    const previewImage = document.createElement('img');
+    previewImage.setAttribute('class', 'preview-image');
+    previewImage.setAttribute('src', blob);
+
+    // 生成したHTMLの要素をブラウザに表示させる
+    previewWrapper.appendChild(previewImage);
+    previewList.appendChild(previewWrapper);
+  };
+
+  // file_fieldを生成・表示する関数
+  const buildNewFileField = () => {
+  
+    // 2枚目用のfile_fieldを作成
+    const newFileField = document.createElement('input');
+    newFileField.setAttribute('type', 'file');
+    newFileField.setAttribute('name', 'post[images][]');
+
+    // 最後のfile_fieldを取得
+    const lastFileField = document.querySelector('input[type="file"][name="post[images][]"]:last-child');
+    
+    // nextDataIndex = 最後のfile_fieldのdata-index + 1
+    const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
+    newFileField.setAttribute('data-index', nextDataIndex);
+
+    // 生成したfile_fieldを表示
+    const fileFieldsArea = document.querySelector('.click-upload');
+    fileFieldsArea.appendChild(newFileField);
+  };
+  
+  // input要素で値の変化が起きた際に呼び出される関数の中身
+  const changedFileField = (e) => {
 
     // data-index（何番目を操作しているか）を取得
     const dataIndex = e.target.getAttribute('data-index');
     console.log( dataIndex);
-    
+
     // 古いプレビューが存在する場合は削除
     const alreadyPreview = document.querySelector('.preview');
       if (alreadyPreview) {
@@ -29,33 +64,13 @@ document.addEventListener('turbo:load', function(){
       const blob = window.URL.createObjectURL(file);
       console.log(blob);
 
-      // 画像を表示するためのdiv要素を生成
-      const previewWrapper = document.createElement('div');
-      previewWrapper.setAttribute('class', 'preview');
-      previewWrapper.setAttribute('data-index', dataIndex);
+      buildPreviewImage(dataIndex, blob);
+      buildNewFileField();
+  };
 
-      // 表示する画像を生成
-      const previewImage = document.createElement('img');
-      previewImage.setAttribute('class', 'preview-image');
-      previewImage.setAttribute('src', blob);
-
-      // 生成したHTMLの要素をブラウザに表示させる
-      previewWrapper.appendChild(previewImage);
-      previewList.appendChild(previewWrapper);
-
-      // 2枚目用のfile_fieldを作成
-      const newFileField = document.createElement('input');
-      newFileField.setAttribute('type', 'file');
-      newFileField.setAttribute('name', 'post[images][]');
-
-      // 最後のfile_fieldを取得
-      const lastFileField = document.querySelector('input[type="file"][name="post[images][]"]:last-child');
-      // nextDataIndex = 最後のfile_fieldのdata-index + 1
-      const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
-      newFileField.setAttribute('data-index', nextDataIndex);
-
-      // 生成したfile_fieldを表示
-      const fileFieldsArea = document.querySelector('.click-upload');
-      fileFieldsArea.appendChild(newFileField);
-    });
+    // input要素を取得
+    // const fileField = document.querySelector('input[type="file"][name="post[image]"]');
+    const fileField = document.querySelector('input[type="file"][name="post[images][]"]');
+    // input要素で値の変化が起きた際に呼び出される関数
+    fileField.addEventListener('change', changedFileField);
 });

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -22,8 +22,14 @@ document.addEventListener('turbo:load', function(){
     previewImage.setAttribute('class', 'preview-image');
     previewImage.setAttribute('src', blob);
 
+    // 削除ボタンを生成
+    const deleteButton = document.createElement("div");
+    deleteButton.setAttribute("class", "image-delete-button");
+    deleteButton.innerText = "削除";
+
     // 生成したHTMLの要素をブラウザに表示させる
     previewWrapper.appendChild(previewImage);
+    previewWrapper.appendChild(deleteButton);
     previewList.appendChild(previewWrapper);
   };
 

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -32,6 +32,7 @@ document.addEventListener('turbo:load', function(){
       // 画像を表示するためのdiv要素を生成
       const previewWrapper = document.createElement('div');
       previewWrapper.setAttribute('class', 'preview');
+      previewWrapper.setAttribute('data-index', dataIndex);
 
       // 表示する画像を生成
       const previewImage = document.createElement('img');

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -10,7 +10,8 @@ document.addEventListener('turbo:load', function(){
   console.log("preview.jsが読み込まれました");
 
     // input要素を取得
-    const fileField = document.querySelector('input[type="file"][name="post[image]"]');
+    // const fileField = document.querySelector('input[type="file"][name="post[image]"]');
+    const fileField = document.querySelector('input[type="file"][name="post[images][]"]');
     // input要素で値の変化が起きた際に呼び出される関数
     fileField.addEventListener('change', function(e){
     // 古いプレビューが存在する場合は削除

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -69,6 +69,10 @@ document.addEventListener('turbo:load', function(){
     deletePreviewImage.remove();
     const deleteFileField = document.querySelector(`input[type="file"][data-index="${dataIndex}"]`);
     deleteFileField.remove();
+
+    // 画像の枚数が最大のときに削除ボタンを押した場合、file_fieldを1つ追加する
+    const imageCount = document.querySelectorAll(".preview").length;
+    if (imageCount == imageLimits - 1) buildNewFileField();
   };
   
   // input要素で値の変化が起きた際に呼び出される関数の中身

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -48,6 +48,12 @@ document.addEventListener('turbo:load', function(){
       newFileField.setAttribute('type', 'file');
       newFileField.setAttribute('name', 'post[images][]');
 
+      // 最後のfile_fieldを取得
+      const lastFileField = document.querySelector('input[type="file"][name="post[images][]"]:last-child');
+      // nextDataIndex = 最後のfile_fieldのdata-index + 1
+      const nextDataIndex = Number(lastFileField.getAttribute('data-index')) +1;
+      newFileField.setAttribute('data-index', nextDataIndex);
+
       // 生成したfile_fieldを表示
       const fileFieldsArea = document.querySelector('.click-upload');
       fileFieldsArea.appendChild(newFileField);

--- a/preview_app_rails7/app/javascript/preview.js
+++ b/preview_app_rails7/app/javascript/preview.js
@@ -49,6 +49,14 @@ document.addEventListener('turbo:load', function(){
     const fileFieldsArea = document.querySelector('.click-upload');
     fileFieldsArea.appendChild(newFileField);
   };
+
+  // 指定したdata-indexを持つプレビューとfile_fieldを削除する
+  const deleteImage = (dataIndex) => {
+    const deletePreviewImage = document.querySelector(`.preview[data-index="${dataIndex}"]`);
+    deletePreviewImage.remove();
+    const deleteFileField = document.querySelector(`input[type="file"][data-index="${dataIndex}"]`);
+    deleteFileField.remove();
+  };
   
   // input要素で値の変化が起きた際に呼び出される関数の中身
   const changedFileField = (e) => {
@@ -64,6 +72,13 @@ document.addEventListener('turbo:load', function(){
       // };
       console.log("input要素で値の変化が起きました");
       const file = e.target.files[0];
+
+      // fileが空 = 何も選択しなかったのでプレビュー等を削除して終了する
+      if (!file) {
+        deleteImage(dataIndex);
+        return null;
+      };
+
       const blob = window.URL.createObjectURL(file);
       console.log(blob);
 

--- a/preview_app_rails7/app/models/post.rb
+++ b/preview_app_rails7/app/models/post.rb
@@ -3,4 +3,7 @@ class Post < ApplicationRecord
   has_many_attached :images
   validates :text, presence: true
   validates :images, presence: true
+  validates :images, length: { minimum: 1, maximum: 5, message: "は1枚以上5枚以下にしてください" }
+end
+
 end

--- a/preview_app_rails7/app/models/post.rb
+++ b/preview_app_rails7/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
-  has_one_attached :image
+  # has_one_attached :image
+  has_many_attached :images
   validates :text, presence: true
-  validates :image, presence: true
+  validates :images, presence: true
 end

--- a/preview_app_rails7/app/views/posts/_form.html.erb
+++ b/preview_app_rails7/app/views/posts/_form.html.erb
@@ -6,7 +6,10 @@
   <div class="image-field">
     <div id="previews"></div>
     <div class="click-upload">
-      <%= f.file_field :image %>
+      <%# <%= f.file_field :image %> 
+      <%= f.file_field :images, name: 'post[images][]', data: {index: 0} %>
+                                                        <%# data: {index: 0}=後ほど画像の削除等を行う際に、
+                                                            何番目の画像が操作されたのかを判断するために使用 %>
     </div>
   </div>
   <div class="submit-btn">

--- a/preview_app_rails7/app/views/posts/index.html.erb
+++ b/preview_app_rails7/app/views/posts/index.html.erb
@@ -2,7 +2,8 @@
 <h3><%= link_to '新規投稿', new_post_path%></h3>
 <% @posts.each do |post| %>
   <div class="posted-content">
-    <%= image_tag post.image %><br>
+    <%# <%= image_tag post.image %><br>
+    <%= image_tag post.images[0] %><br>
     <%= post.text%><br>
     <%= link_to '詳細', post_path(post.id)%>
   </div>

--- a/preview_app_rails7/app/views/posts/show.html.erb
+++ b/preview_app_rails7/app/views/posts/show.html.erb
@@ -1,6 +1,14 @@
 <h3>詳細ページ</h3>
 <div class="posted-content">
-  <%= image_tag @post.image %><br>
+  <%# <%= image_tag @post.image %><br>
+   <%= image_tag @post.images[0], class: "main-image" %><br>
+  <div class="other-images">
+    <% @post.images[1..-1].each do |image| %>
+      <div class="other-image">
+        <%= image_tag image %>
+      </div>
+    <%end%>
+  </div>
   <%= @post.text%><br>
   <%= link_to '編集', edit_post_path(@post.id)%>
 </div>


### PR DESCRIPTION
# WHAT
複数枚画像の投稿機能とそのプレビュー表示機能を実装
・5枚を上限に複数枚画像を選択することができ、それぞれプレビュー表示がされる
・画像の選び直しも可能

# WHY

商品を出品する際に複数枚画像の投稿機能とそのプレビュー表示機能を実装するメリットは以下のものが挙げられます

・商品の詳細な説明:
複数の画像を使用することで、商品を多角的に示すことができます。例えば、商品の全体像、特定のディテール、使用方法、商品のサイズ感など、異なる視点からユーザーに示すことができ、商品の理解度を深めます。
・購入意欲の向上:
顧客は商品を購入する前にその実物をしっかり確認したいと考えています。高品質な画像と多様なアングルの提示は、購入意欲を高め、成約率を向上させる要因となります。
・選び直しの利便性:
画像選び直しの機能があることで、出品者は誤って選択した画像を簡単に変更でき、自分が求める最適な画像を提供できます。この機能は、出品者のストレスを軽減し、投稿プロセスをよりスムーズにします。
・視覚的な魅力の強化:
複数の画像がユーザーの目を引き、商品リスト内での視覚的な魅力を強化します。特にオンライン市場では、魅力的なビジュアルが競争力を高める重要な要素です。
・エラーの低減:
プレビュー表示によって、出品者は自分が選択した画像が実際にどのように投稿されるかを事前に確認でき、誤入力や選択ミスを防ぐことができます。これにより出品後の修正手間も減ります。
・競争力の向上:
他の出品者と比較して、豊富な画像を持つ商品は注目を集めやすく、新規の顧客を引き寄せる可能性が高まります。この結果、より高い販売機会を得ることができます。

